### PR TITLE
Add optimized JansenRit model

### DIFF
--- a/tvb/simulator/models.py
+++ b/tvb/simulator/models.py
@@ -1970,12 +1970,13 @@ class JRFast(JansenRit):
 
         l['c0'], l['c1'] = coupling
 
-        # TODO local_coupling
+        # self.cvar = numpy.array([1, 2], dtype=numpy.int32)
+        l['lc0'], l['lc1'] = local_coupling * y[1], local_coupling * y[2]
 
         self.dy[:3] = y[3:]
 
         ev('A * a * (2.0 * nu_max / (1.0 + exp(r * (v0 - (y1 - y2))))) - 2.0 * a * y3 - a ** 2 * y0', l, g, out=self.dy[3], casting='no')
-        ev('A * a * (mu + a_2 * J * (2.0 * nu_max / (1.0 + exp(r * (v0 - (a_1 * J * y0))))) + (c0 - c1)) - 2.0 * a * y4 - a ** 2 * y1', l, g, out=self.dy[4], casting='no')
+        ev('A * a * (mu + a_2 * J * (2.0 * nu_max / (1.0 + exp(r * (v0 - (a_1 * J * y0))))) + (c0 - c1) + (lc0 - lc1)) - 2.0 * a * y4 - a ** 2 * y1', l, g, out=self.dy[4], casting='no')
         ev('B * b * (a_4 * J * (2.0 * nu_max / (1.0 + exp(r * (v0 - (a_3 * J * y0)))))) - 2.0 * b * y5 - b ** 2 * y2', l, g, out=self.dy[5], casting='no')
 
         return self.dy

--- a/tvb/simulator/models.py
+++ b/tvb/simulator/models.py
@@ -1937,6 +1937,49 @@ class JansenRit(Model):
         """
     )
 
+class JRFast(JansenRit):
+    """
+    This is an optimized version of the above JansenRit model, using numexpr and
+    constant memory (as far as is obvious).
+
+    Note that it caches parameters and derivative arrays on the first call to
+    the dfun method, so if you change the number of nodes or the parameters, you
+    need to invalidate the cache by setting the invalid_dfun_cache attribute to
+    True.
+
+    """
+
+    invalid_dfun_cache = True
+
+    #@profile
+    def dfun(self, y, coupling, local_coupling=0.0, ev=numexpr.evaluate):
+
+        if self.invalid_dfun_cache:
+            self.dy = y.copy() * 0.0
+            self.dfunlocals = {}
+            for k in ['nu_max', 'r', 'v0', 'a_1', 'J', 'a_3', 'A', 'a', 'mu', 
+                    'a_2', 'B', 'b', 'a_4']:
+                self.dfunlocals[k] = getattr(self, k)
+            self.dfunglobals = {}    
+            self.invalid_dfun_cache = False
+
+        l = self.dfunlocals
+        g = self.dfunglobals
+
+        l['y0'], l['y1'], l['y2'], l['y3'], l['y4'], l['y5'] = y
+
+        l['c0'], l['c1'] = coupling
+
+        # TODO local_coupling
+
+        self.dy[:3] = y[3:]
+
+        ev('A * a * (2.0 * nu_max / (1.0 + exp(r * (v0 - (y1 - y2))))) - 2.0 * a * y3 - a ** 2 * y0', l, g, out=self.dy[3], casting='no')
+        ev('A * a * (mu + a_2 * J * (2.0 * nu_max / (1.0 + exp(r * (v0 - (a_1 * J * y0))))) + (c0 - c1)) - 2.0 * a * y4 - a ** 2 * y1', l, g, out=self.dy[4], casting='no')
+        ev('B * b * (a_4 * J * (2.0 * nu_max / (1.0 + exp(r * (v0 - (a_3 * J * y0)))))) - 2.0 * b * y5 - b ** 2 * y2', l, g, out=self.dy[5], casting='no')
+
+        return self.dy
+
 
 
 class Generic2dOscillator(Model):


### PR DESCRIPTION
This adds an optimized JanseRit model that includes local coupling (the original does not). 

Optimization proceeds by using numexpr and almost entirely avoid allocation. The dot product with `local_coupling` still results in temporaries, but would require some digging in the scipy sparse lib because no `out=` keyword argument is available.

Profiling with surface simulation shows a 10x reduction in time spent evaluating the differential equations. Significant additional time is required to evaluate local coupling product, but this is expected. 
