### PR TITLE
change equations scientific/pulse train for vectors

### DIFF
--- a/tvb/datatypes/equations_scientific.py
+++ b/tvb/datatypes/equations_scientific.py
@@ -169,9 +169,9 @@ class PulseTrainScientific(equations_data.PulseTrainData, EquationScientific):
         onset = self.parameters["onset"]
         off = var < onset
         var = numpy.roll(var, int(off.sum() + 1))
-        var[:, 0:off.sum()] = 0.0
+        var[..., 0:off.sum()] = 0.0
         self._pattern = numexpr.evaluate(self.equation, global_dict=self.parameters)
-        self._pattern[:, 0:off.sum()] = 0.0
+        self._pattern[..., 0:off.sum()] = 0.0
 
 
     pattern = property(fget=_get_pattern, fset=_set_pattern)


### PR DESCRIPTION
In case of a vector for `var` in the class PulseTrainScientific, (e.g. when using plot_pattern with a PulseTrain stimulus), a dimension error shows up. The ellipsis avoid the assumption over the number of dimensions of `var`.
