### PR TITLE
Improve setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ class build_ext(_build_ext):
         numpy_inc = numpy.get_include()
         for ext in self.extensions:
             ext.include_dirs.append(numpy_inc)
-        super(build_ext, self).run()
+        _build_ext.run(self)
 
 
 LIBRARY_VERSION = "1.5"

--- a/setup.py
+++ b/setup.py
@@ -33,19 +33,17 @@ Mark TVB-Simulator-Library as a Python import.
 Mention dependencies for this package.
 """
 
-import os
-import shutil
-import setuptools
-from setuptools import Extension
+from setuptools import setup, find_packages, Extension
+from setuptools.command.build_ext import build_ext as _build_ext
 
-try:
-    import numpy
-    from Cython.Distutils import build_ext
-except ImportError:
-    # It is not easy to make setuptools install them before attempting to install the c extensions
-    raise ImportError("Please install numpy and Cython before TVB library. "
-                      "We depend on them to compile Cython extensions.")
 
+class build_ext(_build_ext):
+    def run(self):
+        import numpy
+        numpy_inc = numpy.get_include()
+        for ext in self.extensions:
+            ext.include_dirs.append(numpy_inc)
+        super(build_ext, self).run()
 
 
 LIBRARY_VERSION = "1.5"
@@ -54,17 +52,15 @@ TVB_TEAM = "Stuart Knock, Marmaduke Woodman, Paula Sanz Leon, Jan Fousek, Lia Do
 TVB_INSTALL_REQUIREMENTS = ["networkx", "nibabel", "numpy", "numba", "numexpr", "scikit-learn", "scipy", "gdist"]
 
 
-cython_ext = [
-    Extension("tvb._speedups.history", ["tvb/_speedups/history.pyx"], include_dirs=[numpy.get_include()])
-]
-
-setuptools.setup(
+setup(
     name='tvb',
     description='A package for performing whole brain simulations',
     url='https://github.com/the-virtual-brain/scientific_library',
     version=LIBRARY_VERSION,
-    packages=setuptools.find_packages(),
-    ext_modules=cython_ext,
+    packages=find_packages(),
+    ext_modules=[
+        Extension("tvb._speedups.history", ["tvb/_speedups/history.pyx"])
+    ],
     cmdclass={"build_ext": build_ext},
     license='GPL',
     author=TVB_TEAM,
@@ -79,18 +75,5 @@ progress, and a subject of on-going research efforts. Please refer
 to the following article for more information: 
 
 http://www.frontiersin.org/Journal/10.3389/fninf.2013.00010/abstract
-
 """
 )
-
-## Cleanup after EGG install. These are created by running setup.py in the source tree
-shutil.rmtree('tvb.egg-info', True)
-
-# clean up after extension build
-shutil.rmtree('build', True)
-SPEEDUPS_DIR = os.path.join('tvb', '_speedups')
-
-for f in os.listdir(SPEEDUPS_DIR):
-    if f.endswith('.c'):
-        os.remove(os.path.join(SPEEDUPS_DIR, f))
-


### PR DESCRIPTION
Just like the-virtual-brain/tvb-geodesic#8.

> The current version of setup.py suffer from a typical problem among scientific
> python packages that prevents the package from being installable using pip.
> 
> The problem lies in the import numpy line. Pip needs to be able to run
> setup.py egg_info to figure out the dependencies but this fails when
> setup.py tried to import numpy, which isn't installed yet.
> 
> This patched uses a solution inspired from http://stackoverflow.com/a/21621689.
> 
> It consists in implementing a custom build_ext class that defers the need for
> numpy presence to building extension time, which is after the requirements
> have been installed.
> 
> This should be enough to let the user install the package using pip install
