### PR TITLE
TVB-2371 Implement signal energy computation

### DIFF
--- a/tvb/datatypes/time_series.py
+++ b/tvb/datatypes/time_series.py
@@ -385,7 +385,7 @@ class TimeSeries(types_mapped.MappedType):
                    "Dimensions": self.labels_ordering,
                    "Time units": self.sample_period_unit,
                    "Sample period": self.sample_period,
-                   "Length": self.sample_period * self.read_data_shaperead_data_shape('data')[0]}
+                   "Length": self.sample_period * self.get_data_shape('data')[0]}
         summary.update(self.get_info_about_array('data'))
         return summary
 

--- a/tvb/datatypes/time_series.py
+++ b/tvb/datatypes/time_series.py
@@ -142,9 +142,15 @@ class TimeSeries(types_mapped.MappedType):
             b, a = scipy.signal.butter(order, [low, high], btype='band')
             return b, a
 
-        def filter_data(data, lowcut, highcut, fs, order=5):
-            # get filter coefficients
-            b, a = butterworth_bandpass(lowcut, highcut, fs, order=order)
+        def filter_data(data):
+            # filter coefficients
+            # b, a = butterworth_bandpass(0.5,100,500,5)
+
+            b = [2.85877183e-03, 0.00000000e+00, -8.57631550e-03,
+                 2.53383906e-18, 8.57631550e-03, 0.00000000e+00,
+                 -2.85877183e-03]
+            a = [1., -5.37586409, 12.06062864, -14.4603995,
+                 9.77614063, -3.53427674, 0.53377106]
 
             # filter data
             y = scipy.signal.lfilter(b, a, data, axis=0)
@@ -179,17 +185,16 @@ class TimeSeries(types_mapped.MappedType):
         data_to_compute_energy=data_page[:, channel_slice].reshape(len(channels_list),time_length)
         energy=numpy.empty(shape=(len(channels_list),time_length))
 
-        # energy = [[]for i in range(len(data_to_compute_energy))]
         # filter data for each channel
         for i in range(len(data_to_compute_energy)):
-            data_to_compute_energy[i] = filter_data(data_to_compute_energy[i], 0.5, 100, 500, order=5)
+            data_to_compute_energy[i] = filter_data(data_to_compute_energy[i])
         # calculate energy for each channel
         for i in range(len(data_to_compute_energy)):
             energy[i] = compute_signal_energy(data_to_compute_energy[i], int(interval_length))
 
         # remap the range of the energy to make it appear visible in the 3d viewer
         for i in range(len(energy)):
-            m = interp1d([0, numpy.max(energy[i])], [1, 7])
+            m = interp1d([numpy.min(energy[i]), numpy.max(energy[i])], [1, 7])
             for j in range(len(energy[0])):
                 energy[i][j]=m(energy[i][j])
 


### PR DESCRIPTION
The energy is filtered and computed based on the time window size in the time series datatype. 
The result is calculated for every time point in the data. For the time window length that will exceed the last time point, the energy is computed to the last time point.
For example for time data [1,2,3] and length 2 the last energy will only calculate at time 3.

