### PR TITLE
Constraints to state variable handling by integrator's schemes

### DIFF
--- a/tvb/basic/traits/__init__.py
+++ b/tvb/basic/traits/__init__.py
@@ -117,8 +117,8 @@ Suggested reading is `Unifying Types and Classes`_ and th `Python data model`_.
 
 """
 
-import core
-import traited_interface, traited_interface2
+from . import core
+from . import traited_interface, traited_interface2
 from tvb.basic.profile import TvbProfile
 
 # Add interfaces based on configured parameter on classes

--- a/tvb/simulator/models/base.py
+++ b/tvb/simulator/models/base.py
@@ -60,7 +60,7 @@ class Model(core.Type):
     _nvar = None
     number_of_modes = 1
     cvar = None
-    state_variable_constraint = None
+    state_variable_boundaries = None
 
     def _build_observer(self):
         template = ("def observe(state):\n"
@@ -86,21 +86,21 @@ class Model(core.Type):
         super(Model, self).configure()
         self.update_derived_parameters()
         self._build_observer()
-        # Make sure that if there are any state variable constraints, ...
-        if isinstance(self.state_variable_constraint, dict):
-            for sv, constraint in self. state_variable_constraint.items():
+        # Make sure that if there are any state variable boundaries, ...
+        if isinstance(self.state_variable_boundaries, dict):
+            for sv, bounds in self. state_variable_boundaries.items():
                 try:
-                    # ...the constraints correspond to model's state variables,
+                    # ...the boundaries correspond to model's state variables,
                     self.state_variables.index(sv)
                 except:
                     # TODO: Add the correct type of error and error message
                     raise
                 # and for every two sided constraint, the left boundary is lower than the right one
-                if constraint[0] is not None and constraint[1] is not None:
-                    assert constraint[0] <= constraint[1]
-        elif self.state_variable_constraint is not None:
+                if bounds[0] is not None and bounds[1] is not None:
+                    assert bounds[0] <= bounds[1]
+        elif self.state_variable_boundaries is not None:
             # TODO: Add here a warning or, even, error?
-            self.state_variable_constraint = None
+            self.state_variable_boundaries = None
 
     @property
     def nvar(self):

--- a/tvb/simulator/models/base.py
+++ b/tvb/simulator/models/base.py
@@ -60,6 +60,7 @@ class Model(core.Type):
     _nvar = None
     number_of_modes = 1
     cvar = None
+    state_variable_constraint = None
 
     def _build_observer(self):
         template = ("def observe(state):\n"
@@ -85,6 +86,21 @@ class Model(core.Type):
         super(Model, self).configure()
         self.update_derived_parameters()
         self._build_observer()
+        # Make sure that if there are any state variable constraints, ...
+        if isinstance(self.state_variable_constraint, dict):
+            for sv, constraint in self. state_variable_constraint.items():
+                try:
+                    # ...the constraints correspond to model's state variables,
+                    self.state_variables.index(sv)
+                except:
+                    # TODO: Add the correct type of error and error message
+                    raise
+                # and for every two sided constraint, the left boundary is lower than the right one
+                if constraint[0] is not None and constraint[1] is not None:
+                    assert constraint[0] <= constraint[1]
+        elif self.state_variable_constraint is not None:
+            # TODO: Add here a warning or, even, error?
+            self.state_variable_constraint = None
 
     @property
     def nvar(self):

--- a/tvb/simulator/models/wong_wang.py
+++ b/tvb/simulator/models/wong_wang.py
@@ -37,17 +37,9 @@ from numba import guvectorize, float64
 @guvectorize([(float64[:],)*11], '(n),(m)' + ',()'*8 + '->(n)', nopython=True)
 def _numba_dfun(S, c, a, b, d, g, ts, w, j, io, dx):
     "Gufunc for reduced Wong-Wang model equations."
-
-    if S[0] < 0.0:
-        S_constraint = 0.0
-    elif S[0] > 1.0:
-        S_constraint = 1.0
-    else:
-        S_constraint = S[0]
-
-    x = w[0]*j[0]*S_constraint + io[0] + j[0]*c[0]
+    x = w[0]*j[0]*S[0] + io[0] + j[0]*c[0]
     h = (a[0]*x - b[0]) / (1 - numpy.exp(-d[0]*(a[0]*x - b[0])))
-    dx[0] = - (S_constraint / ts[0]) + (1.0 - S_constraint) * h * g[0]
+    dx[0] = - (S[0] / ts[0]) + (1.0 - S[0]) * h * g[0]
 
 
 class ReducedWongWang(ModelNumbaDfun):
@@ -147,8 +139,8 @@ class ReducedWongWang(ModelNumbaDfun):
     )
 
     # Used for phase-plane axis ranges and to bound random initial() conditions.
-    state_variable_constraint = basic.Dict(
-        label="State Variable constraints [lo, hi]",
+    state_variable_boundaries = basic.Dict(
+        label="State Variable boundaries [lo, hi]",
         default={"S": numpy.array([0.0, 1.0])},
         doc="""The values for each state-variable should be set to encompass
             the boundaries of the dynamic range of that state-variable. Set None for one-sided boundaries""",
@@ -182,8 +174,7 @@ class ReducedWongWang(ModelNumbaDfun):
 
         """
         S   = state_variables[0, :]
-        S[S<0] = 0.
-        S[S>1] = 1.
+
         c_0 = coupling[0, :]
 
 

--- a/tvb/simulator/models/wong_wang.py
+++ b/tvb/simulator/models/wong_wang.py
@@ -39,13 +39,15 @@ def _numba_dfun(S, c, a, b, d, g, ts, w, j, io, dx):
     "Gufunc for reduced Wong-Wang model equations."
 
     if S[0] < 0.0:
-        dx[0] = 0.0 - S[0]
+        S_constraint = 0.0
     elif S[0] > 1.0:
-        dx[0] = 1.0 - S[0]
+        S_constraint = 1.0
     else:
-        x = w[0]*j[0]*S[0] + io[0] + j[0]*c[0]
-        h = (a[0]*x - b[0]) / (1 - numpy.exp(-d[0]*(a[0]*x - b[0])))
-        dx[0] = - (S[0] / ts[0]) + (1.0 - S[0]) * h * g[0]
+        S_constraint = S[0]
+
+    x = w[0]*j[0]*S_constraint + io[0] + j[0]*c[0]
+    h = (a[0]*x - b[0]) / (1 - numpy.exp(-d[0]*(a[0]*x - b[0])))
+    dx[0] = - (S_constraint / ts[0]) + (1.0 - S_constraint) * h * g[0]
 
 
 class ReducedWongWang(ModelNumbaDfun):
@@ -144,13 +146,21 @@ class ReducedWongWang(ModelNumbaDfun):
         order=9
     )
 
+    # Used for phase-plane axis ranges and to bound random initial() conditions.
+    state_variable_constraint = basic.Dict(
+        label="State Variable constraints [lo, hi]",
+        default={"S": numpy.array([0.0, 1.0])},
+        doc="""The values for each state-variable should be set to encompass
+            the boundaries of the dynamic range of that state-variable. Set None for one-sided boundaries""",
+        order=10)
+
     variables_of_interest = basic.Enumerate(
         label="Variables watched by Monitors",
         options=["S"],
         default=["S"],
         select_multiple=True,
         doc="""default state variables to be monitored""",
-        order=10)
+        order=11)
 
     state_variables = ['S']
     _nvar = 1

--- a/tvb/simulator/models/wong_wang_exc_io_inh_i.py
+++ b/tvb/simulator/models/wong_wang_exc_io_inh_i.py
@@ -44,16 +44,30 @@ def _numba_dfun(S, c, ae, be, de, ge, te, wp, we, jn, ai, bi, di, gi, ti, wi, ji
 
     cc = g[0]*jn[0]*c[0]
 
-    jnSe = jn[0]*S[0]
-    x = wp[0]*jnSe - ji[0]*S[1] + we[0]*io[0] + cc
+    if S[0] < 0.0:
+        S_e = 0.0  # - S[0] # TODO: clarify the boundary to be reflective or saturated!!!
+    elif S[0] > 1.0:
+        S_e = 1.0  # - S[0] # TODO: clarify the boundary to be reflective or saturated!!!
+    else:
+        S_e = S[0]
+
+    if S[1] < 0.0:
+        S_i = 0.0  # - S[1]  TODO: clarify the boundary to be reflective or saturated!!!
+    elif S[1] > 1.0:
+        S_i = 1.0  #  - S[1] TODO: clarify the boundary to be reflective or saturated!!!
+    else:
+        S_i = S[1]
+
+    jnSe = jn[0]*S_e
+    x = wp[0]*jnSe - ji[0]*S_i + we[0]*io[0] + cc
     x = ae[0]*x - be[0]
     h = x / (1 - numpy.exp(-de[0]*x))
-    dx[0] = - (S[0] / te[0]) + (1.0 - S[0]) * h * ge[0]
+    dx[0] = - (S_e / te[0]) + (1.0 - S_e) * h * ge[0]
 
-    x = jnSe - S[1] + wi[0]*io[0] + l[0]*cc
+    x = jnSe - S_i + wi[0]*io[0] + l[0]*cc
     x = ai[0]*x - bi[0]
     h = x / (1 - numpy.exp(-di[0]*x))
-    dx[1] = - (S[1] / ti[0]) + h * gi[0]
+    dx[1] = - (S_i / ti[0]) + h * gi[0]
 
 
 class ReducedWongWangExcIOInhI(ModelNumbaDfun):
@@ -260,6 +274,8 @@ class ReducedWongWangExcIOInhI(ModelNumbaDfun):
 
         """
         S = state_variables[:, :]
+        S[S < 0] = 0.
+        S[S > 1] = 1.
 
         c_0 = coupling[0, :]
 

--- a/tvb/simulator/models/wong_wang_exc_io_inh_i.py
+++ b/tvb/simulator/models/wong_wang_exc_io_inh_i.py
@@ -45,16 +45,16 @@ def _numba_dfun(S, c, ae, be, de, ge, te, wp, we, jn, ai, bi, di, gi, ti, wi, ji
     cc = g[0]*jn[0]*c[0]
 
     if S[0] < 0.0:
-        S_e = 0.0  # - S[0] # TODO: clarify the boundary to be reflective or saturated!!!
+        S_e = 0.0
     elif S[0] > 1.0:
-        S_e = 1.0  # - S[0] # TODO: clarify the boundary to be reflective or saturated!!!
+        S_e = 1.0
     else:
         S_e = S[0]
 
     if S[1] < 0.0:
-        S_i = 0.0  # - S[1]  TODO: clarify the boundary to be reflective or saturated!!!
+        S_i = 0.0
     elif S[1] > 1.0:
-        S_i = 1.0  #  - S[1] TODO: clarify the boundary to be reflective or saturated!!!
+        S_i = 1.0
     else:
         S_i = S[1]
 

--- a/tvb/simulator/models/wong_wang_exc_io_inh_i.py
+++ b/tvb/simulator/models/wong_wang_exc_io_inh_i.py
@@ -44,30 +44,16 @@ def _numba_dfun(S, c, ae, be, de, ge, te, wp, we, jn, ai, bi, di, gi, ti, wi, ji
 
     cc = g[0]*jn[0]*c[0]
 
-    if S[0] < 0.0:
-        S_e = 0.0  # - S[0] # TODO: clarify the boundary to be reflective or saturated!!!
-    elif S[0] > 1.0:
-        S_e = 1.0  # - S[0] # TODO: clarify the boundary to be reflective or saturated!!!
-    else:
-        S_e = S[0]
-
-    if S[1] < 0.0:
-        S_i = 0.0  # - S[1]  TODO: clarify the boundary to be reflective or saturated!!!
-    elif S[1] > 1.0:
-        S_i = 1.0  #  - S[1] TODO: clarify the boundary to be reflective or saturated!!!
-    else:
-        S_i = S[1]
-
-    jnSe = jn[0]*S_e
-    x = wp[0]*jnSe - ji[0]*S_i + we[0]*io[0] + cc
+    jnSe = jn[0]*S[0]
+    x = wp[0]*jnSe - ji[0]*S[1] + we[0]*io[0] + cc
     x = ae[0]*x - be[0]
     h = x / (1 - numpy.exp(-de[0]*x))
-    dx[0] = - (S_e / te[0]) + (1.0 - S_e) * h * ge[0]
+    dx[0] = - (S[0] / te[0]) + (1.0 - S[0]) * h * ge[0]
 
-    x = jnSe - S_i + wi[0]*io[0] + l[0]*cc
+    x = jnSe - S[1] + wi[0]*io[0] + l[0]*cc
     x = ai[0]*x - bi[0]
     h = x / (1 - numpy.exp(-di[0]*x))
-    dx[1] = - (S_i / ti[0]) + h * gi[0]
+    dx[1] = - (S[1] / ti[0]) + h * gi[0]
 
 
 class ReducedWongWangExcIOInhI(ModelNumbaDfun):
@@ -234,13 +220,21 @@ class ReducedWongWangExcIOInhI(ModelNumbaDfun):
         order=22
     )
 
+    # Used for phase-plane axis ranges and to bound random initial() conditions.
+    state_variable_constraint = basic.Dict(
+        label="State Variable constraints [lo, hi]",
+        default={"S_e": numpy.array([0.0, 1.0]), "S_i": numpy.array([0.0, 1.0])},
+        doc="""The values for each state-variable should be set to encompass
+            the boundaries of the dynamic range of that state-variable. Set None for one-sided boundaries""",
+        order=23)
+
     variables_of_interest = basic.Enumerate(
         label="Variables watched by Monitors",
         options=['S_e', 'S_i'],
         default=['S_e', 'S_i'],
         select_multiple=True,
         doc="""default state variables to be monitored""",
-        order=23)
+        order=24)
 
     state_variables = ['S_e', 'S_i']
     _nvar = 2
@@ -266,8 +260,6 @@ class ReducedWongWangExcIOInhI(ModelNumbaDfun):
 
         """
         S = state_variables[:, :]
-        S[S < 0] = 0.
-        S[S > 1] = 1.
 
         c_0 = coupling[0, :]
 

--- a/tvb/simulator/models/wong_wang_exc_io_inh_i.py
+++ b/tvb/simulator/models/wong_wang_exc_io_inh_i.py
@@ -44,30 +44,17 @@ def _numba_dfun(S, c, ae, be, de, ge, te, wp, we, jn, ai, bi, di, gi, ti, wi, ji
 
     cc = g[0]*jn[0]*c[0]
 
-    if S[0] < 0.0:
-        S_e = 0.0
-    elif S[0] > 1.0:
-        S_e = 1.0
-    else:
-        S_e = S[0]
+    jnSe = jn[0]*S[0]
 
-    if S[1] < 0.0:
-        S_i = 0.0
-    elif S[1] > 1.0:
-        S_i = 1.0
-    else:
-        S_i = S[1]
-
-    jnSe = jn[0]*S_e
-    x = wp[0]*jnSe - ji[0]*S_i + we[0]*io[0] + cc
+    x = wp[0]*jnSe - ji[0]*S[1] + we[0]*io[0] + cc
     x = ae[0]*x - be[0]
     h = x / (1 - numpy.exp(-de[0]*x))
-    dx[0] = - (S_e / te[0]) + (1.0 - S_e) * h * ge[0]
+    dx[0] = - (S[0] / te[0]) + (1.0 - S[0]) * h * ge[0]
 
-    x = jnSe - S_i + wi[0]*io[0] + l[0]*cc
+    x = jnSe - S[1] + wi[0]*io[0] + l[0]*cc
     x = ai[0]*x - bi[0]
     h = x / (1 - numpy.exp(-di[0]*x))
-    dx[1] = - (S_i / ti[0]) + h * gi[0]
+    dx[1] = - (S[1] / ti[0]) + h * gi[0]
 
 
 class ReducedWongWangExcIOInhI(ModelNumbaDfun):
@@ -235,8 +222,8 @@ class ReducedWongWangExcIOInhI(ModelNumbaDfun):
     )
 
     # Used for phase-plane axis ranges and to bound random initial() conditions.
-    state_variable_constraint = basic.Dict(
-        label="State Variable constraints [lo, hi]",
+    state_variable_boundaries = basic.Dict(
+        label="State Variable boundaries [lo, hi]",
         default={"S_e": numpy.array([0.0, 1.0]), "S_i": numpy.array([0.0, 1.0])},
         doc="""The values for each state-variable should be set to encompass
             the boundaries of the dynamic range of that state-variable. Set None for one-sided boundaries""",
@@ -274,8 +261,6 @@ class ReducedWongWangExcIOInhI(ModelNumbaDfun):
 
         """
         S = state_variables[:, :]
-        S[S < 0] = 0.
-        S[S > 1] = 1.
 
         c_0 = coupling[0, :]
 

--- a/tvb/simulator/simulator.py
+++ b/tvb/simulator/simulator.py
@@ -233,6 +233,18 @@ class Simulator(core.Type):
         self.coupling.configure()
         self.model.configure()
         self.integrator.configure()
+        if isinstance(self.model.state_variable_constraint, dict):
+            indices = []
+            boundaries = []
+            for sv, sv_bounds in self.model.state_variable_constraint.items():
+                indices.append(self.model.state_variables.index(sv))
+                boundaries.append(sv_bounds)
+            sort_inds = numpy.sort(indices)
+            self.integrator.constraint_state_variable_indices = numpy.array(indices)[sort_inds]
+            self.integrator.constraint_state_variable_boundaries = numpy.array(boundaries)[sort_inds]
+        else:
+            self.integrator.constraint_state_variable_indices = None
+            self.integrator.constraint_state_variable_boundaries = None
         # monitors needs to be a list or tuple, even if there is only one...
         if not isinstance(self.monitors, (list, tuple)):
             self.monitors = [self.monitors]
@@ -465,6 +477,8 @@ class Simulator(core.Type):
                     history[:ic_shape[0], :, :, :] = initial_conditions
                     history = numpy.roll(history, shift, axis=0)
                 self.current_step += ic_shape[0] - 1
+        # TODO: confirm that this is doing what I think it is doing and that this is where this line should be placed!
+        numpy.apply_along_axis(self.integrator.constrain_state, 0, history)
         LOG.info('Final initial history shape is %r', history.shape)
         # create initial state from history
         self.current_state = history[self.current_step % self.horizon].copy()

--- a/tvb/simulator/simulator.py
+++ b/tvb/simulator/simulator.py
@@ -477,7 +477,6 @@ class Simulator(core.Type):
                     history[:ic_shape[0], :, :, :] = initial_conditions
                     history = numpy.roll(history, shift, axis=0)
                 self.current_step += ic_shape[0] - 1
-        # TODO: confirm that this is doing what I think it is doing and that this is where this line should be placed!
         self.integrator.constrain_state(numpy.swapaxes(history, 0, 1))
         LOG.info('Final initial history shape is %r', history.shape)
         # create initial state from history

--- a/tvb/simulator/simulator.py
+++ b/tvb/simulator/simulator.py
@@ -477,8 +477,8 @@ class Simulator(core.Type):
                     history[:ic_shape[0], :, :, :] = initial_conditions
                     history = numpy.roll(history, shift, axis=0)
                 self.current_step += ic_shape[0] - 1
-        if self.constraint_state_variable_boundaries is not None:
-            self.integrator.constrain_state(numpy.swapaxes(history, 0, 1))
+        if self.integrator.state_variable_boundaries is not None:
+            self.integrator.bound_state(numpy.swapaxes(history, 0, 1))
         LOG.info('Final initial history shape is %r', history.shape)
         # create initial state from history
         self.current_state = history[self.current_step % self.horizon].copy()

--- a/tvb/simulator/simulator.py
+++ b/tvb/simulator/simulator.py
@@ -239,7 +239,7 @@ class Simulator(core.Type):
             for sv, sv_bounds in self.model.state_variable_constraint.items():
                 indices.append(self.model.state_variables.index(sv))
                 boundaries.append(sv_bounds)
-            sort_inds = numpy.sort(indices)
+            sort_inds = numpy.argsort(indices)
             self.integrator.constraint_state_variable_indices = numpy.array(indices)[sort_inds]
             self.integrator.constraint_state_variable_boundaries = numpy.array(boundaries)[sort_inds]
         else:
@@ -478,7 +478,7 @@ class Simulator(core.Type):
                     history = numpy.roll(history, shift, axis=0)
                 self.current_step += ic_shape[0] - 1
         # TODO: confirm that this is doing what I think it is doing and that this is where this line should be placed!
-        numpy.apply_along_axis(self.integrator.constrain_state, 0, history)
+        self.integrator.constrain_state(numpy.swapaxes(history, 0, 1))
         LOG.info('Final initial history shape is %r', history.shape)
         # create initial state from history
         self.current_state = history[self.current_step % self.horizon].copy()

--- a/tvb/simulator/simulator.py
+++ b/tvb/simulator/simulator.py
@@ -477,7 +477,8 @@ class Simulator(core.Type):
                     history[:ic_shape[0], :, :, :] = initial_conditions
                     history = numpy.roll(history, shift, axis=0)
                 self.current_step += ic_shape[0] - 1
-        self.integrator.constrain_state(numpy.swapaxes(history, 0, 1))
+        if self.constraint_state_variable_boundaries is not None:
+            self.integrator.constrain_state(numpy.swapaxes(history, 0, 1))
         LOG.info('Final initial history shape is %r', history.shape)
         # create initial state from history
         self.current_state = history[self.current_step % self.horizon].copy()

--- a/tvb/tests/library/simulator/integrators_test.py
+++ b/tvb/tests/library/simulator/integrators_test.py
@@ -132,10 +132,10 @@ class TestIntegrators(BaseTestCase):
     def test_scipy_dopri5(self):
         self._scipy_scheme_tester('Dopri5')
 
-    def test_constrain(self):
+    def test_bound(self):
         vode = integrators.VODE(
-            constraint_state_variable_indices=numpy.r_[0, 1, 2, 3],
-            constraint_state_variable_values=numpy.array([[0.0, 1.0], [None, 1.0], [0.0, None], [None, None]])
+            bounded_state_variable_indices=numpy.r_[0, 1, 2, 3],
+            state_variable_boundaries=numpy.array([[0.0, 1.0], [None, 1.0], [0.0, None], [None, None]])
         )
         x = numpy.ones((5, 4, 2))
         x[:, 0, ] = -x[:, 0, ]
@@ -143,7 +143,7 @@ class TestIntegrators(BaseTestCase):
         x0 = numpy.array(x)
         for i in range(10):
             x = vode.scheme(x, self._dummy_dfun, 0.0, 0.0, 0.0)
-        for idx, val in zip(vode.constraint_state_variable_indices, vode.constraint_state_variable_indices):
+        for idx, val in zip(vode.bounded_state_variable_indices, vode.state_variable_boundaries):
             if idx == 0:
                 assert numpy.all(x[idx] >= val[0])
                 assert numpy.all(x[idx] <= val[1])

--- a/tvb/tests/library/simulator/integrators_test.py
+++ b/tvb/tests/library/simulator/integrators_test.py
@@ -132,6 +132,30 @@ class TestIntegrators(BaseTestCase):
     def test_scipy_dopri5(self):
         self._scipy_scheme_tester('Dopri5')
 
+    def test_constrain(self):
+        vode = integrators.VODE(
+            constraint_state_variable_indices=numpy.r_[0, 1, 2, 3],
+            constraint_state_variable_values=numpy.array([[0.0, 1.0], [None, 1.0], [0.0, None], [None, None]])
+        )
+        x = numpy.ones((5, 4, 2))
+        x[:, 0, ] = -x[:, 0, ]
+        x[:, 1, ] = 2 * x[:, 1, ]
+        x0 = numpy.array(x)
+        for i in range(10):
+            x = vode.scheme(x, self._dummy_dfun, 0.0, 0.0, 0.0)
+        for idx, val in zip(vode.constraint_state_variable_indices, vode.constraint_state_variable_indices):
+            if idx == 0:
+                assert numpy.all(x[idx] >= val[0])
+                assert numpy.all(x[idx] <= val[1])
+            elif idx == 1:
+                assert numpy.all(x[idx] <= val[1])
+                assert numpy.allclose(x[idx, 0], x0[idx, 0])
+            elif idx == 2:
+                assert numpy.all(x[idx] >= val[0])
+                assert numpy.allclose(x[idx, 1], x0[idx, 1])
+            else:
+                assert numpy.allclose(x[idx], x0[idx])
+
     def test_clamp(self):
         vode = integrators.VODE(
             clamped_state_variable_indices=numpy.r_[0, 3],


### PR DESCRIPTION
Followed clamp_state example, but took if statements outside clamp_state and constraint_state methods to avoid the function stack when no constraint or clamping applies.

In the base model I am checking for consistency of the user input or model property on constraints.

I updated the two wong-wang models by adding the constraints and modifying the _numba_dfun of the old model, to not have a reflective boundary any more.

In the simulator, I configure the integrator when then model has constraints, and I constrain the history during history configuration.

I added a test similar to the test for state clamping.

