### PR TITLE
Minor fix in simulator error message

### DIFF
--- a/tvb/simulator/simulator.py
+++ b/tvb/simulator/simulator.py
@@ -452,7 +452,7 @@ class Simulator(core.Type):
                 return self._configure_history(initial_conditions)
             elif ic_shape[1:] != self.good_history_shape[1:]:
                 raise ValueError("Incorrect history sample shape %s, expected %s"
-                                 % ic_shape[1:], self.good_history_shape[1:])
+                                 % (ic_shape[1:], self.good_history_shape[1:]))
             else:
                 if ic_shape[0] >= self.horizon:
                     LOG.debug("Using last %d time-steps for history.", self.horizon)


### PR DESCRIPTION
I came across that yesterday and thought it would be nice to fix it as it's a really tiny thing.

You need to put tuples in brackets in that case as otherwise, you get:
```
TypeError: not all arguments converted during string formatting
```

Eg. Wrong:

```
'--- %s ---' % (1,2,3)
```

Right:
```
'--- %s ---' % ((1,2,3),)
```

